### PR TITLE
Update grpregOverlap.R

### DIFF
--- a/LICENCE
+++ b/LICENCE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 LAMINE TOURE
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/R/grpregOverlap.R
+++ b/R/grpregOverlap.R
@@ -96,8 +96,8 @@ gamma2beta<- function(gamma, incidence.mat, grp.vec, family) {
 # -------------------------------------------------------------------------------
 expandX <- function(X, group) {
   incidence.mat <- incidenceMatrix(X, group) # group membership incidence matrix
-  over.mat <- Matrix(incidence.mat %*% t(incidence.mat), sparse = TRUE, 
-                     dimnames = dimnames(incidence.mat)) # overlap matrix
+  over.mat <- Matrix(incidence.mat %*% t(incidence.mat), sparse = TRUE) 
+                     #dimnames = dimnames(incidence.mat)) # overlap matrix
   grp.vec <- rep(1:nrow(over.mat), times = diag(over.mat)) # group index vector
   
   # expand X to X.latent


### PR DESCRIPTION
Hi Yaohui,
Thank you for your interesting package.
While working with it, I had an error with the ExpandX function with the dimnames in the **Overlap matrix**.
I propose this:
```r
expandX <- function(X, group) {
  incidence.mat <- incidenceMatrix(X, group) # group membership incidence matrix
  over.mat <- Matrix(incidence.mat %*% t(incidence.mat), sparse = TRUE) 
                    # dimnames = dimnames(incidence.mat)) # overlap matrix
  grp.vec <- rep(1:nrow(over.mat), times = diag(over.mat)) # group index vector
  
  # expand X to X.latent
  X.latent <- NULL
  names <- NULL

  ## the following code will automatically remove variables not included in 'group'
  for(i in 1:nrow(incidence.mat)) {
    idx <- incidence.mat[i,]==1
    X.latent <- cbind(X.latent, X[, idx, drop=FALSE])
    names <- c(names, colnames(incidence.mat)[idx])
#     colnames(X.latent) <- c(colnames(X.latent), colnames(X)[incidence.mat[i,]==1])
  }
  colnames(X.latent) <- paste('grp', grp.vec, '_', names, sep = "")
  X.latent
}
```
Because when creating the overlap matrix, the dimnames are not the same with the incidence matrix. 
Thanks you,
Best 